### PR TITLE
Feat/pagination 30

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1581,9 +1581,9 @@
       "dev": true
     },
     "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
       "hasInstallScript": true,
       "optional": true,
@@ -1898,9 +1898,9 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
       "dev": true,
       "funding": [
         {
@@ -2058,9 +2058,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.27",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.27.tgz",
-      "integrity": "sha512-gY/ACJtJPSmUFPDCHtX78+01fHa64FaU4zaaWfuh1MhGJISufJAH4cun6k/8fwsHYeK4UQmENQK+tRLCFJE8JQ==",
+      "version": "8.4.38",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
+      "integrity": "sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==",
       "dev": true,
       "funding": [
         {
@@ -2077,9 +2077,9 @@
         }
       ],
       "dependencies": {
-        "nanoid": "^3.3.6",
+        "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "source-map-js": "^1.2.0"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -2234,9 +2234,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "3.26.3",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.26.3.tgz",
-      "integrity": "sha512-7Tin0C8l86TkpcMtXvQu6saWH93nhG3dGQ1/+l5V2TDMceTxO7kDiK6GzbfLWNNxqJXm591PcEZUozZm51ogwQ==",
+      "version": "3.29.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.4.tgz",
+      "integrity": "sha512-oWzmBZwvYrU0iJHtDmhsm662rC15FRXmcjCk1xD771dFDx5jJ02ufAQQTn0etB2emNk4J9EZg/yWKpsn9BWGRw==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -2326,9 +2326,9 @@
       }
     },
     "node_modules/source-map-js": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
+      "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -2447,14 +2447,14 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.6.tgz",
-      "integrity": "sha512-EY6Mm8vJ++S3D4tNAckaZfw3JwG3wa794Vt70M6cNJ6NxT87yhq7EC8Rcap3ahyHdo8AhCmV9PTk+vG1HiYn1A==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.3.tgz",
+      "integrity": "sha512-kQL23kMeX92v3ph7IauVkXkikdDRsYMGTVl5KY2E9OY4ONLvkHf04MDTbnfo6NKxZiDLWzVpP5oTa8hQD8U3dg==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.18.10",
-        "postcss": "^8.4.26",
-        "rollup": "^3.25.2"
+        "postcss": "^8.4.27",
+        "rollup": "^3.27.1"
       },
       "bin": {
         "vite": "bin/vite.js"

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -11,9 +11,15 @@ const Button = ({
   cssText,
   icon,
   cssIcon,
+  inlineStyles,
 }: ButtonType) => {
   return (
-    <button disabled={disabled} onClick={onClick} className={cssButton}>
+    <button
+      disabled={disabled}
+      onClick={onClick}
+      className={cssButton}
+      style={inlineStyles}
+    >
       {icon && (
         <i className={cssIcon}>
           <FontAwesomeIcon icon={icon} />

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -5,6 +5,7 @@ import { ButtonType } from "./ButtonType";
 
 const Button = ({
   onClick,
+  disabled,
   cssButton,
   text,
   cssText,
@@ -12,7 +13,7 @@ const Button = ({
   cssIcon,
 }: ButtonType) => {
   return (
-    <button onClick={onClick} className={cssButton}>
+    <button disabled={disabled} onClick={onClick} className={cssButton}>
       {icon && (
         <i className={cssIcon}>
           <FontAwesomeIcon icon={icon} />

--- a/src/components/button/ButtonType.ts
+++ b/src/components/button/ButtonType.ts
@@ -8,6 +8,7 @@ type ButtonWithText = {
   cssText: string;
   icon?: IconDefinition;
   cssIcon?: string;
+  inlineStyles?: React.CSSProperties;
 };
 
 type ButtonWithoutText = {
@@ -18,6 +19,7 @@ type ButtonWithoutText = {
   cssText?: string;
   icon: IconDefinition;
   cssIcon: string;
+  inlineStyles?: React.CSSProperties;
 };
 
 export type ButtonType = ButtonWithText | ButtonWithoutText;

--- a/src/components/button/ButtonType.ts
+++ b/src/components/button/ButtonType.ts
@@ -2,6 +2,7 @@ import { IconDefinition } from "@fortawesome/fontawesome-svg-core";
 
 type ButtonWithText = {
   onClick: (e?: React.MouseEvent<HTMLButtonElement>) => void;
+  disabled: boolean;
   cssButton: string;
   text: string;
   cssText: string;
@@ -11,6 +12,7 @@ type ButtonWithText = {
 
 type ButtonWithoutText = {
   onClick: (e?: React.MouseEvent<HTMLButtonElement>) => void;
+  disabled: boolean;
   cssButton: string;
   text?: string;
   cssText?: string;

--- a/src/components/pagination/Pagination.tsx
+++ b/src/components/pagination/Pagination.tsx
@@ -21,6 +21,7 @@ const Pagination = ({
   maxPagesToShow,
 }: PaginationType) => {
   console.log("🚀 ~ currentPage:", currentPage);
+
   const totalPages = Math.ceil(totalItems / itemsPerPage);
 
   const handlePageChange = (newPage: number) => {

--- a/src/components/pagination/Pagination.tsx
+++ b/src/components/pagination/Pagination.tsx
@@ -22,10 +22,12 @@ const Pagination = ({
 }: PaginationType) => {
   const location = useLocation();
   const searchParams = new URLSearchParams(location.search);
-  const query = searchParams.get("q");
+  const query = searchParams.get("q") || "";
   const { page } = useParams();
   const currentPage: number = Number(page);
+
   const totalPages = Math.ceil(totalItems / itemsPerPage);
+
   return (
     <div className={styles.pagination}>
       <ul className={styles.ul}>

--- a/src/components/pagination/Pagination.tsx
+++ b/src/components/pagination/Pagination.tsx
@@ -2,15 +2,13 @@ import { faArrowLeft, faArrowRight } from "@fortawesome/free-solid-svg-icons";
 
 /* Components */
 import Button from "../../components/button/Button";
+import RenderPageNumbers from "./renderPageNumbers/RenderPageNumbers";
 
 /* Theme context */
 import { ThemeContext } from "../../contexts/ThemeProvider";
 
 /* Styles */
 import styles from "./pagination.module.css";
-
-/* Utils */
-import renderPageNumbers from "./utils/renderPageNumbers/renderPageNumbers";
 
 const Pagination = ({
   totalItems,
@@ -26,13 +24,6 @@ const Pagination = ({
     onPageChange(newPage);
   };
 
-  const pageNumbers = renderPageNumbers(
-    totalPages,
-    currentPage,
-    handlePageChange,
-    maxPagesToShow
-  );
-
   return (
     <div className={styles.pagination}>
       <ul className={styles.ul}>
@@ -45,7 +36,12 @@ const Pagination = ({
             cssIcon={""}
           />
         </li>
-        {pageNumbers}
+        <RenderPageNumbers
+          totalPages={totalPages}
+          currentPage={currentPage}
+          handlePageChange={handlePageChange}
+          maxPagesToShow={maxPagesToShow}
+        />
         <li key="next">
           <Button
             onClick={() => handlePageChange(currentPage + 1)}

--- a/src/components/pagination/Pagination.tsx
+++ b/src/components/pagination/Pagination.tsx
@@ -10,13 +10,16 @@ import { ThemeContext } from "../../contexts/ThemeProvider";
 /* Styles */
 import styles from "./pagination.module.css";
 
+/* Types */
+import { PaginationType } from "./PaginationType";
+
 const Pagination = ({
   totalItems,
   itemsPerPage,
   currentPage,
   onPageChange,
   maxPagesToShow,
-}) => {
+}: PaginationType) => {
   console.log("🚀 ~ currentPage:", currentPage);
   const totalPages = Math.ceil(totalItems / itemsPerPage);
 

--- a/src/components/pagination/Pagination.tsx
+++ b/src/components/pagination/Pagination.tsx
@@ -1,7 +1,9 @@
+import { Link, useLocation, useParams } from "react-router-dom";
+
 import { faArrowLeft, faArrowRight } from "@fortawesome/free-solid-svg-icons";
 
 /* Components */
-import Button from "../../components/button/Button";
+import Icon from "../../components/icon/Icon";
 import RenderPageNumbers from "./renderPageNumbers/RenderPageNumbers";
 
 /* Theme context */
@@ -16,45 +18,33 @@ import { PaginationType } from "./PaginationType";
 const Pagination = ({
   totalItems,
   itemsPerPage,
-  currentPage,
-  onPageChange,
   maxPagesToShow,
 }: PaginationType) => {
-  console.log("🚀 ~ currentPage:", currentPage);
-
+  const location = useLocation();
+  const searchParams = new URLSearchParams(location.search);
+  const query = searchParams.get("q");
+  const { page } = useParams();
+  const currentPage: number = Number(page);
   const totalPages = Math.ceil(totalItems / itemsPerPage);
-
-  const handlePageChange = (newPage: number) => {
-    onPageChange(newPage);
-  };
-
   return (
     <div className={styles.pagination}>
       <ul className={styles.ul}>
-        <li key="previous">
-          <Button
-            onClick={() => handlePageChange(currentPage - 1)}
-            disabled={currentPage === 1}
-            cssButton={""}
-            icon={faArrowLeft}
-            cssIcon={""}
-          />
-        </li>
+        <Link
+          to={`/search/${currentPage - 1}?q=${encodeURIComponent(query)}`}
+          key="previous"
+        >
+          <Icon icon={faArrowLeft} css="" />
+        </Link>
         <RenderPageNumbers
           totalPages={totalPages}
-          currentPage={currentPage}
-          handlePageChange={handlePageChange}
           maxPagesToShow={maxPagesToShow}
         />
-        <li key="next">
-          <Button
-            onClick={() => handlePageChange(currentPage + 1)}
-            disabled={currentPage === totalPages}
-            cssButton={""}
-            icon={faArrowRight}
-            cssIcon={""}
-          />
-        </li>
+        <Link
+          to={`/search/${currentPage + 1}?q=${encodeURIComponent(query)}`}
+          key="next"
+        >
+          <Icon icon={faArrowRight} css="" />
+        </Link>
       </ul>
     </div>
   );

--- a/src/components/pagination/Pagination.tsx
+++ b/src/components/pagination/Pagination.tsx
@@ -1,14 +1,4 @@
-import { useContext } from "react";
-import { Link, useLocation, useParams } from "react-router-dom";
-
-import { faArrowLeft, faArrowRight } from "@fortawesome/free-solid-svg-icons";
-
-/* Components */
-import Icon from "../../components/icon/Icon";
 import RenderPageNumbers from "./renderPageNumbers/RenderPageNumbers";
-
-/* Theme context */
-import { ThemeContext } from "../../contexts/ThemeProvider";
 
 /* Styles */
 import styles from "./pagination.module.css";
@@ -21,41 +11,15 @@ const Pagination = ({
   itemsPerPage,
   maxPagesToShow,
 }: PaginationType) => {
-  const location = useLocation();
-  const searchParams = new URLSearchParams(location.search);
-  const query = searchParams.get("q") || "";
-  const { page } = useParams();
-  const currentPage: number = Number(page);
-
-  const { isDarkMode } = useContext(ThemeContext);
-
-  const buttonTheme = isDarkMode
-    ? styles.buttonsDarkMode
-    : styles.buttonsLightMode;
-
   const totalPages = Math.ceil(totalItems / itemsPerPage);
 
   return (
     <div className={styles.pagination}>
       <ul className={styles.ul}>
-        <Link
-          to={`/search/${currentPage - 1}?q=${encodeURIComponent(query)}`}
-          key="previous"
-          className={`${styles.buttons} ${buttonTheme}`}
-        >
-          <Icon icon={faArrowLeft} css="" />
-        </Link>
         <RenderPageNumbers
           totalPages={totalPages}
           maxPagesToShow={maxPagesToShow}
         />
-        <Link
-          to={`/search/${currentPage + 1}?q=${encodeURIComponent(query)}`}
-          key="next"
-          className={`${styles.buttons} ${buttonTheme}`}
-        >
-          <Icon icon={faArrowRight} css="" />
-        </Link>
       </ul>
     </div>
   );

--- a/src/components/pagination/Pagination.tsx
+++ b/src/components/pagination/Pagination.tsx
@@ -1,0 +1,63 @@
+import { faArrowLeft, faArrowRight } from "@fortawesome/free-solid-svg-icons";
+
+/* Components */
+import Button from "../../components/button/Button";
+
+/* Theme context */
+import { ThemeContext } from "../../contexts/ThemeProvider";
+
+/* Styles */
+import styles from "./pagination.module.css";
+
+/* Utils */
+import renderPageNumbers from "./utils/renderPageNumbers/renderPageNumbers";
+
+const Pagination = ({
+  totalItems,
+  itemsPerPage,
+  currentPage,
+  onPageChange,
+  maxPagesToShow,
+}) => {
+  console.log("🚀 ~ currentPage:", currentPage);
+  const totalPages = Math.ceil(totalItems / itemsPerPage);
+
+  const handlePageChange = (newPage: number) => {
+    onPageChange(newPage);
+  };
+
+  const pageNumbers = renderPageNumbers(
+    totalPages,
+    currentPage,
+    handlePageChange,
+    maxPagesToShow
+  );
+
+  return (
+    <div className={styles.pagination}>
+      <ul className={styles.ul}>
+        <li key="previous">
+          <Button
+            onClick={() => handlePageChange(currentPage - 1)}
+            disabled={currentPage === 1}
+            cssButton={""}
+            icon={faArrowLeft}
+            cssIcon={""}
+          />
+        </li>
+        {pageNumbers}
+        <li key="next">
+          <Button
+            onClick={() => handlePageChange(currentPage + 1)}
+            disabled={currentPage === totalPages}
+            cssButton={""}
+            icon={faArrowRight}
+            cssIcon={""}
+          />
+        </li>
+      </ul>
+    </div>
+  );
+};
+
+export default Pagination;

--- a/src/components/pagination/Pagination.tsx
+++ b/src/components/pagination/Pagination.tsx
@@ -1,3 +1,4 @@
+import { useContext } from "react";
 import { Link, useLocation, useParams } from "react-router-dom";
 
 import { faArrowLeft, faArrowRight } from "@fortawesome/free-solid-svg-icons";
@@ -26,6 +27,12 @@ const Pagination = ({
   const { page } = useParams();
   const currentPage: number = Number(page);
 
+  const { isDarkMode } = useContext(ThemeContext);
+
+  const buttonTheme = isDarkMode
+    ? styles.buttonsDarkMode
+    : styles.buttonsLightMode;
+
   const totalPages = Math.ceil(totalItems / itemsPerPage);
 
   return (
@@ -34,6 +41,7 @@ const Pagination = ({
         <Link
           to={`/search/${currentPage - 1}?q=${encodeURIComponent(query)}`}
           key="previous"
+          className={`${styles.buttons} ${buttonTheme}`}
         >
           <Icon icon={faArrowLeft} css="" />
         </Link>
@@ -44,6 +52,7 @@ const Pagination = ({
         <Link
           to={`/search/${currentPage + 1}?q=${encodeURIComponent(query)}`}
           key="next"
+          className={`${styles.buttons} ${buttonTheme}`}
         >
           <Icon icon={faArrowRight} css="" />
         </Link>

--- a/src/components/pagination/PaginationType.ts
+++ b/src/components/pagination/PaginationType.ts
@@ -1,7 +1,5 @@
 export type PaginationType = {
   totalItems: number;
   itemsPerPage: number;
-  currentPage: number;
-  onPageChange: (page: number) => void;
   maxPagesToShow: number;
 };

--- a/src/components/pagination/PaginationType.ts
+++ b/src/components/pagination/PaginationType.ts
@@ -1,0 +1,7 @@
+export type PaginationType = {
+  totalItems: number;
+  itemsPerPage: number;
+  currentPage: number;
+  onPageChange: (page: number) => void;
+  maxPagesToShow: number;
+};

--- a/src/components/pagination/pagination.module.css
+++ b/src/components/pagination/pagination.module.css
@@ -3,13 +3,46 @@
   justify-content: center;
   /* width: 100%; */
   /* height: 30px; */
-  background-color: blue;
+  /* background-color: blue; */
 }
 .ul {
   display: flex;
   gap: 8px;
 }
 
-.active {
-  color: red;
+.buttons {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-width: 2.5rem;
+  min-height: 2.5rem;
+  /* text-align: center; */
+  font-size: var(--text-sm);
+  border-width: 1px;
+  border-style: solid;
+  border-radius: var(--principal-border-radius);
+}
+
+/* On light mode */
+.buttonsLightMode {
+  background-color: var(--background-tertiary-light-mode);
+  border-color: rgb(43, 43, 43, 0.3);
+  color: var(--text-primary-dark);
+}
+
+.buttonsLightMode:hover {
+  background-color: rgba(0, 0, 0, 0.2);
+  /*   background-color: var(--text-secondary-dark);
+  opacity: 0.3; */
+}
+
+/* On light mode */
+.buttonsDarkMode {
+  background-color: var(--background-tertiary-dark-mode);
+  border-color: rgba(227, 230, 230, 0.3);
+  color: var(--text-primary-light);
+}
+
+.buttonsDarkMode:hover {
+  background-color: rgba(227, 227, 227, 0.2);
 }

--- a/src/components/pagination/pagination.module.css
+++ b/src/components/pagination/pagination.module.css
@@ -1,9 +1,7 @@
 .pagination {
   display: flex;
   justify-content: center;
-  /* width: 100%; */
-  /* height: 30px; */
-  /* background-color: blue; */
+  margin: var(--spacing-lg) 0;
 }
 .ul {
   display: flex;
@@ -16,7 +14,6 @@
   align-items: center;
   min-width: 2.5rem;
   min-height: 2.5rem;
-  /* text-align: center; */
   font-size: var(--text-sm);
   border-width: 1px;
   border-style: solid;
@@ -32,8 +29,6 @@
 
 .buttonsLightMode:hover {
   background-color: rgba(0, 0, 0, 0.2);
-  /*   background-color: var(--text-secondary-dark);
-  opacity: 0.3; */
 }
 
 /* On light mode */

--- a/src/components/pagination/pagination.module.css
+++ b/src/components/pagination/pagination.module.css
@@ -7,37 +7,3 @@
   display: flex;
   gap: 8px;
 }
-
-.buttons {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  min-width: 2.5rem;
-  min-height: 2.5rem;
-  font-size: var(--text-sm);
-  border-width: 1px;
-  border-style: solid;
-  border-radius: var(--principal-border-radius);
-}
-
-/* On light mode */
-.buttonsLightMode {
-  background-color: var(--background-tertiary-light-mode);
-  border-color: rgb(43, 43, 43, 0.3);
-  color: var(--text-primary-dark);
-}
-
-.buttonsLightMode:hover {
-  background-color: rgba(0, 0, 0, 0.2);
-}
-
-/* On light mode */
-.buttonsDarkMode {
-  background-color: var(--background-tertiary-dark-mode);
-  border-color: rgba(227, 230, 230, 0.3);
-  color: var(--text-primary-light);
-}
-
-.buttonsDarkMode:hover {
-  background-color: rgba(227, 227, 227, 0.2);
-}

--- a/src/components/pagination/pagination.module.css
+++ b/src/components/pagination/pagination.module.css
@@ -1,12 +1,13 @@
 .pagination {
   display: flex;
-  width: 100%;
-  height: 30px;
+  justify-content: center;
+  /* width: 100%; */
+  /* height: 30px; */
   background-color: blue;
 }
 .ul {
   display: flex;
-  gap: 7px;
+  gap: 8px;
 }
 
 .active {

--- a/src/components/pagination/pagination.module.css
+++ b/src/components/pagination/pagination.module.css
@@ -1,0 +1,14 @@
+.pagination {
+  display: flex;
+  width: 100%;
+  height: 30px;
+  background-color: blue;
+}
+.ul {
+  display: flex;
+  gap: 7px;
+}
+
+.active {
+  color: red;
+}

--- a/src/components/pagination/renderPageNumbers/RenderPageNumberType.ts
+++ b/src/components/pagination/renderPageNumbers/RenderPageNumberType.ts
@@ -1,0 +1,6 @@
+export type RenderPageNumberType = {
+  totalPages: number;
+  currentPage: number;
+  handlePageChange: (arg: number) => void;
+  maxPagesToShow: number;
+};

--- a/src/components/pagination/renderPageNumbers/RenderPageNumberType.ts
+++ b/src/components/pagination/renderPageNumbers/RenderPageNumberType.ts
@@ -1,6 +1,4 @@
 export type RenderPageNumberType = {
   totalPages: number;
-  currentPage: number;
-  handlePageChange: (arg: number) => void;
   maxPagesToShow: number;
 };

--- a/src/components/pagination/renderPageNumbers/RenderPageNumbers.tsx
+++ b/src/components/pagination/renderPageNumbers/RenderPageNumbers.tsx
@@ -1,3 +1,6 @@
+/* Styles */
+import styles from "./renderPageNumbers.module.css";
+
 /* Types */
 import { RenderPageNumberType } from "./RenderPageNumberType";
 
@@ -22,8 +25,21 @@ const RenderPageNumbers = ({
 
   // Always show page 1
   pageNumbers.push(
-    <li key="1" className={1 === currentPage ? "active" : ""}>
-      <button onClick={() => handlePageChange(1)} disabled={currentPage === 1}>
+    <li
+      key="1"
+      /* className={1 === currentPage ? "active" : ""} */ className={
+        currentPage === 1
+          ? `${styles.pageNumber} ${styles.active}`
+          : styles.pageNumber
+      }
+    >
+      {" "}
+      {/*className={1 === currentPage ? `${styles.pageNumber} ${styles.active}` : styles.pageNumber }*/}
+      <button
+        onClick={() => handlePageChange(1)}
+        disabled={currentPage === 1}
+        className={styles.pageNumber}
+      >
         1
       </button>
     </li>
@@ -31,29 +47,57 @@ const RenderPageNumbers = ({
 
   // Add ellipsis if startPage is greater than 2
   if (startPage > 2) {
-    pageNumbers.push(<li key="ellipsis1">...</li>);
+    pageNumbers.push(
+      <li key="ellipsis1" className={styles.pageNumber}>
+        ...
+      </li>
+    );
   }
 
   // Add the page numbers in the range startPage to endPage
   for (let i = startPage; i <= endPage; i++) {
     pageNumbers.push(
-      <li key={i} className={i === currentPage ? "active" : ""}>
-        <button onClick={() => handlePageChange(i)}>{i}</button>
+      <li
+        key={i}
+        className={
+          currentPage === i
+            ? `${styles.pageNumber} ${styles.active}`
+            : styles.pageNumber
+        }
+      >
+        <button
+          onClick={() => handlePageChange(i)}
+          className={styles.pageNumber}
+        >
+          {i}
+        </button>
       </li>
     );
   }
 
   // Add ellipsis if endPage is less than totalPages - 1
   if (endPage < totalPages - 1) {
-    pageNumbers.push(<li key="ellipsis2">...</li>);
+    pageNumbers.push(
+      <li key="ellipsis2" className={styles.pageNumber}>
+        ...
+      </li>
+    );
   }
 
   // Always show the last page
   pageNumbers.push(
-    <li key={totalPages} className={totalPages === currentPage ? "active" : ""}>
+    <li
+      key={totalPages}
+      className={
+        currentPage === totalPages
+          ? `${styles.pageNumber} ${styles.active}`
+          : styles.pageNumber
+      }
+    >
       <button
         onClick={() => handlePageChange(totalPages)}
         disabled={currentPage === totalPages}
+        className={styles.pageNumber}
       >
         {totalPages}
       </button>

--- a/src/components/pagination/renderPageNumbers/RenderPageNumbers.tsx
+++ b/src/components/pagination/renderPageNumbers/RenderPageNumbers.tsx
@@ -1,3 +1,5 @@
+import { Link, useLocation, useParams } from "react-router-dom";
+
 /* Styles */
 import styles from "./renderPageNumbers.module.css";
 
@@ -6,10 +8,13 @@ import { RenderPageNumberType } from "./RenderPageNumberType";
 
 const RenderPageNumbers = ({
   totalPages,
-  currentPage,
-  handlePageChange,
   maxPagesToShow,
 }: RenderPageNumberType) => {
+  const location = useLocation();
+  const searchParams = new URLSearchParams(location.search);
+  const query = searchParams.get("q");
+  const { page } = useParams();
+  const currentPage: number = Number(page);
   // Array to store page numbers
   const pageNumbers = [];
 
@@ -25,24 +30,17 @@ const RenderPageNumbers = ({
 
   // Always show page 1
   pageNumbers.push(
-    <li
+    <Link
       key="1"
-      /* className={1 === currentPage ? "active" : ""} */ className={
+      to={`/search/1?q=${encodeURIComponent(query)}`}
+      className={
         currentPage === 1
           ? `${styles.pageNumber} ${styles.active}`
           : styles.pageNumber
       }
     >
-      {" "}
-      {/*className={1 === currentPage ? `${styles.pageNumber} ${styles.active}` : styles.pageNumber }*/}
-      <button
-        onClick={() => handlePageChange(1)}
-        disabled={currentPage === 1}
-        className={styles.pageNumber}
-      >
-        1
-      </button>
-    </li>
+      1
+    </Link>
   );
 
   // Add ellipsis if startPage is greater than 2
@@ -57,21 +55,17 @@ const RenderPageNumbers = ({
   // Add the page numbers in the range startPage to endPage
   for (let i = startPage; i <= endPage; i++) {
     pageNumbers.push(
-      <li
+      <Link
         key={i}
+        to={`/search/${i}?q=${encodeURIComponent(query)}`}
         className={
           currentPage === i
             ? `${styles.pageNumber} ${styles.active}`
             : styles.pageNumber
         }
       >
-        <button
-          onClick={() => handlePageChange(i)}
-          className={styles.pageNumber}
-        >
-          {i}
-        </button>
-      </li>
+        {i}
+      </Link>
     );
   }
 
@@ -86,22 +80,17 @@ const RenderPageNumbers = ({
 
   // Always show the last page
   pageNumbers.push(
-    <li
+    <Link
       key={totalPages}
+      to={`/search/${totalPages}?q=${encodeURIComponent(query)}`}
       className={
         currentPage === totalPages
           ? `${styles.pageNumber} ${styles.active}`
           : styles.pageNumber
       }
     >
-      <button
-        onClick={() => handlePageChange(totalPages)}
-        disabled={currentPage === totalPages}
-        className={styles.pageNumber}
-      >
-        {totalPages}
-      </button>
-    </li>
+      {totalPages}
+    </Link>
   );
 
   // Return page numbers

--- a/src/components/pagination/renderPageNumbers/RenderPageNumbers.tsx
+++ b/src/components/pagination/renderPageNumbers/RenderPageNumbers.tsx
@@ -90,8 +90,8 @@ const RenderPageNumbers = ({
       to={`/search/1?q=${encodeURIComponent(query)}`}
       className={
         currentPage === 1
-          ? `${styles.pageNumber} ${pageNumberTheme} ${styles.active} `
-          : `${styles.pageNumber} ${pageNumberTheme}`
+          ? `${styles.paginationItem} ${pageNumberTheme} ${styles.active} `
+          : `${styles.paginationItem} ${pageNumberTheme}`
       }
     >
       1
@@ -101,7 +101,10 @@ const RenderPageNumbers = ({
   // Add ellipsis if startPage is greater than 2
   if (startPage > 2) {
     pageNumbers.push(
-      <li key="ellipsis1" className={`${styles.pageNumber} ${ellipsisTheme}`}>
+      <li
+        key="ellipsis1"
+        className={`${styles.paginationItem} ${ellipsisTheme}`}
+      >
         ...
       </li>
     );
@@ -115,8 +118,8 @@ const RenderPageNumbers = ({
         to={`/search/${i}?q=${encodeURIComponent(query)}`}
         className={
           currentPage === i
-            ? `${styles.pageNumber} ${pageNumberTheme} ${styles.active}`
-            : `${styles.pageNumber} ${pageNumberTheme}`
+            ? `${styles.paginationItem} ${pageNumberTheme} ${styles.active}`
+            : `${styles.paginationItem} ${pageNumberTheme}`
         }
       >
         {i}
@@ -127,7 +130,10 @@ const RenderPageNumbers = ({
   // Add ellipsis if endPage is less than totalPages - 1
   if (endPage < totalPages - 1) {
     pageNumbers.push(
-      <li key="ellipsis2" className={`${styles.pageNumber} ${ellipsisTheme}`}>
+      <li
+        key="ellipsis2"
+        className={`${styles.paginationItem} ${ellipsisTheme}`}
+      >
         ...
       </li>
     );
@@ -140,8 +146,8 @@ const RenderPageNumbers = ({
       to={`/search/${totalPages}?q=${encodeURIComponent(query)}`}
       className={
         currentPage === totalPages
-          ? `${styles.pageNumber} ${pageNumberTheme} ${styles.active}`
-          : `${styles.pageNumber} ${pageNumberTheme}`
+          ? `${styles.paginationItem} ${pageNumberTheme} ${styles.active}`
+          : `${styles.paginationItem} ${pageNumberTheme}`
       }
     >
       {totalPages}
@@ -155,7 +161,7 @@ const RenderPageNumbers = ({
         key={"previous"}
         onClick={handlePrev}
         disabled={isDisabledPrev}
-        cssButton={`${styles.buttons} ${buttonTheme}`}
+        cssButton={`${styles.paginationItem} ${buttonTheme}`}
         icon={faArrowLeft}
         cssIcon=""
         inlineStyles={disabledPrevStyle}
@@ -165,7 +171,7 @@ const RenderPageNumbers = ({
         key={"next"}
         onClick={handleNext}
         disabled={isDisabledNext}
-        cssButton={`${styles.buttons} ${buttonTheme}`}
+        cssButton={`${styles.paginationItem} ${buttonTheme}`}
         icon={faArrowRight}
         cssIcon=""
         inlineStyles={disabledNextStyle}

--- a/src/components/pagination/renderPageNumbers/RenderPageNumbers.tsx
+++ b/src/components/pagination/renderPageNumbers/RenderPageNumbers.tsx
@@ -1,5 +1,10 @@
 import { useContext } from "react";
-import { Link, useLocation, useParams } from "react-router-dom";
+import { Link, useLocation, useNavigate, useParams } from "react-router-dom";
+
+import { faArrowLeft, faArrowRight } from "@fortawesome/free-solid-svg-icons";
+
+/* Components */
+import Button from "../../button/Button";
 
 /* Theme context */
 import { ThemeContext } from "../../../contexts/ThemeProvider";
@@ -16,11 +21,18 @@ const RenderPageNumbers = ({
 }: RenderPageNumberType) => {
   const location = useLocation();
   const searchParams = new URLSearchParams(location.search);
+
   const query = searchParams.get("q") || "";
   const { page } = useParams();
   const currentPage: number = Number(page);
 
+  const navigate = useNavigate();
+
   const { isDarkMode } = useContext(ThemeContext);
+
+  const buttonTheme = isDarkMode
+    ? styles.buttonsDarkMode
+    : styles.buttonsLightMode;
 
   const pageNumberTheme = isDarkMode
     ? styles.pageNumberDarkMode
@@ -40,6 +52,36 @@ const RenderPageNumbers = ({
   if (endPage - startPage < maxPagesToShow - 1) {
     startPage = Math.max(2, endPage - maxPagesToShow + 1);
   }
+
+  /* Determines whether the button is enabled or not */
+  const isDisabledPrev = currentPage === 1;
+  const isDisabledNext = currentPage === totalPages;
+
+  /* If the button is disabled, remove the cursor pointer */
+  const disabledPrevStyle = {
+    opacity: isDisabledPrev ? 0.5 : 1,
+    cursor: isDisabledPrev ? "not-allowed" : "pointer",
+  };
+
+  const disabledNextStyle = {
+    opacity: isDisabledNext ? 0.5 : 1,
+    cursor: isDisabledNext ? "not-allowed" : "pointer",
+  };
+
+  /* Manage page changes by using the previous and next buttons */
+  const handlePrev = () => {
+    if (isDisabledPrev) {
+      return;
+    }
+    navigate(`/search/${currentPage - 1}?q=${encodeURIComponent(query)}`);
+  };
+
+  const handleNext = () => {
+    if (isDisabledNext) {
+      return;
+    }
+    navigate(`/search/${currentPage + 1}?q=${encodeURIComponent(query)}`);
+  };
 
   // Always show page 1
   pageNumbers.push(
@@ -107,7 +149,29 @@ const RenderPageNumbers = ({
   );
 
   // Return page numbers
-  return <>{pageNumbers}</>;
+  return (
+    <>
+      <Button
+        key={"previous"}
+        onClick={handlePrev}
+        disabled={isDisabledPrev}
+        cssButton={`${styles.buttons} ${buttonTheme}`}
+        icon={faArrowLeft}
+        cssIcon=""
+        inlineStyles={disabledPrevStyle}
+      />
+      {pageNumbers}
+      <Button
+        key={"next"}
+        onClick={handleNext}
+        disabled={isDisabledNext}
+        cssButton={`${styles.buttons} ${buttonTheme}`}
+        icon={faArrowRight}
+        cssIcon=""
+        inlineStyles={disabledNextStyle}
+      />
+    </>
+  );
 };
 
 export default RenderPageNumbers;

--- a/src/components/pagination/renderPageNumbers/RenderPageNumbers.tsx
+++ b/src/components/pagination/renderPageNumbers/RenderPageNumbers.tsx
@@ -1,9 +1,12 @@
-const renderPageNumbers = (
-  totalPages: number,
-  currentPage: number,
-  handlePageChange: (page: number) => void,
-  maxPagesToShow: number
-): JSX.Element[] => {
+/* Types */
+import { RenderPageNumberType } from "./RenderPageNumberType";
+
+const RenderPageNumbers = ({
+  totalPages,
+  currentPage,
+  handlePageChange,
+  maxPagesToShow,
+}: RenderPageNumberType) => {
   // Array to store page numbers
   const pageNumbers = [];
 
@@ -58,7 +61,7 @@ const renderPageNumbers = (
   );
 
   // Return page numbers
-  return pageNumbers;
+  return <>{pageNumbers}</>;
 };
 
-export default renderPageNumbers;
+export default RenderPageNumbers;

--- a/src/components/pagination/renderPageNumbers/RenderPageNumbers.tsx
+++ b/src/components/pagination/renderPageNumbers/RenderPageNumbers.tsx
@@ -30,6 +30,7 @@ const RenderPageNumbers = ({
 
   const { isDarkMode } = useContext(ThemeContext);
 
+  /* Defines the theme color */
   const buttonTheme = isDarkMode
     ? styles.buttonsDarkMode
     : styles.buttonsLightMode;

--- a/src/components/pagination/renderPageNumbers/RenderPageNumbers.tsx
+++ b/src/components/pagination/renderPageNumbers/RenderPageNumbers.tsx
@@ -1,4 +1,8 @@
+import { useContext } from "react";
 import { Link, useLocation, useParams } from "react-router-dom";
+
+/* Theme context */
+import { ThemeContext } from "../../../contexts/ThemeProvider";
 
 /* Styles */
 import styles from "./renderPageNumbers.module.css";
@@ -12,9 +16,18 @@ const RenderPageNumbers = ({
 }: RenderPageNumberType) => {
   const location = useLocation();
   const searchParams = new URLSearchParams(location.search);
-  const query = searchParams.get("q");
+  const query = searchParams.get("q") || "";
   const { page } = useParams();
   const currentPage: number = Number(page);
+
+  const { isDarkMode } = useContext(ThemeContext);
+
+  const pageNumberTheme = isDarkMode
+    ? styles.pageNumberDarkMode
+    : styles.pageNumberLightMode;
+
+  const ellipsisTheme = isDarkMode ? styles.ellipsisDark : styles.ellipsisLight;
+
   // Array to store page numbers
   const pageNumbers = [];
 
@@ -35,8 +48,8 @@ const RenderPageNumbers = ({
       to={`/search/1?q=${encodeURIComponent(query)}`}
       className={
         currentPage === 1
-          ? `${styles.pageNumber} ${styles.active}`
-          : styles.pageNumber
+          ? `${styles.pageNumber} ${pageNumberTheme} ${styles.active} `
+          : `${styles.pageNumber} ${pageNumberTheme}`
       }
     >
       1
@@ -46,7 +59,7 @@ const RenderPageNumbers = ({
   // Add ellipsis if startPage is greater than 2
   if (startPage > 2) {
     pageNumbers.push(
-      <li key="ellipsis1" className={styles.pageNumber}>
+      <li key="ellipsis1" className={`${styles.pageNumber} ${ellipsisTheme}`}>
         ...
       </li>
     );
@@ -60,8 +73,8 @@ const RenderPageNumbers = ({
         to={`/search/${i}?q=${encodeURIComponent(query)}`}
         className={
           currentPage === i
-            ? `${styles.pageNumber} ${styles.active}`
-            : styles.pageNumber
+            ? `${styles.pageNumber} ${pageNumberTheme} ${styles.active}`
+            : `${styles.pageNumber} ${pageNumberTheme}`
         }
       >
         {i}
@@ -72,7 +85,7 @@ const RenderPageNumbers = ({
   // Add ellipsis if endPage is less than totalPages - 1
   if (endPage < totalPages - 1) {
     pageNumbers.push(
-      <li key="ellipsis2" className={styles.pageNumber}>
+      <li key="ellipsis2" className={`${styles.pageNumber} ${ellipsisTheme}`}>
         ...
       </li>
     );
@@ -85,8 +98,8 @@ const RenderPageNumbers = ({
       to={`/search/${totalPages}?q=${encodeURIComponent(query)}`}
       className={
         currentPage === totalPages
-          ? `${styles.pageNumber} ${styles.active}`
-          : styles.pageNumber
+          ? `${styles.pageNumber} ${pageNumberTheme} ${styles.active}`
+          : `${styles.pageNumber} ${pageNumberTheme}`
       }
     >
       {totalPages}

--- a/src/components/pagination/renderPageNumbers/renderPageNumbers.module.css
+++ b/src/components/pagination/renderPageNumbers/renderPageNumbers.module.css
@@ -1,15 +1,59 @@
 .pageNumber {
+  display: flex;
+  justify-content: center;
+  align-items: center;
   min-width: 2.5rem;
   min-height: 2.5rem;
-  text-align: center;
-  font-size: var(--text-md);
+  font-size: var(--text-lg);
+  border: 1px solid white;
+
   border-radius: var(--principal-border-radius);
   background-color: inherit;
 }
 
-.pageNumber.active {
+/* On light mode */
+.pageNumberLightMode {
+  background-color: var(--background-tertiary-light-mode);
+  border-color: rgb(43, 43, 43, 0.3);
+  color: var(--text-primary-dark);
 }
 
-.active {
-  background-color: orange;
+.pageNumberLightMode:hover {
+  background-color: rgba(15, 17, 17, 0.2);
+}
+
+.pageNumberLightMode.active {
+  background-color: #191919;
+  color: var(--text-primary-light);
+}
+
+/* On dark mode */
+.pageNumberDarkMode {
+  background-color: var(--background-tertiary-dark-mode);
+  border-color: rgba(227, 230, 230, 0.3);
+  color: var(--text-primary-light);
+}
+
+.pageNumberDarkMode:hover {
+  background-color: rgba(227, 227, 227, 0.2);
+}
+
+.pageNumberDarkMode.active {
+  background-color: var(--background-tertiary-light-mode);
+  color: var(--text-primary-dark);
+}
+
+/* * Ellipsis classes */
+/* On light mode */
+.ellipsisLight {
+  background-color: var(--background-tertiary-light-mode);
+  border-color: rgb(43, 43, 43, 0.3);
+  color: var(--text-primary-dark);
+}
+
+/* On dark mode */
+.ellipsisDark {
+  background-color: var(--background-tertiary-dark-mode);
+  border-color: rgba(227, 230, 230, 0.3);
+  color: var(--text-primary-light);
 }

--- a/src/components/pagination/renderPageNumbers/renderPageNumbers.module.css
+++ b/src/components/pagination/renderPageNumbers/renderPageNumbers.module.css
@@ -6,7 +6,6 @@
   min-height: 2.5rem;
   font-size: var(--text-lg);
   border: 1px solid white;
-
   border-radius: var(--principal-border-radius);
   background-color: inherit;
 }

--- a/src/components/pagination/renderPageNumbers/renderPageNumbers.module.css
+++ b/src/components/pagination/renderPageNumbers/renderPageNumbers.module.css
@@ -1,13 +1,18 @@
-.buttons {
+.paginationItem {
   display: flex;
   justify-content: center;
   align-items: center;
   min-width: 2.5rem;
   min-height: 2.5rem;
-  font-size: var(--text-sm);
   border-width: 1px;
   border-style: solid;
   border-radius: var(--principal-border-radius);
+}
+
+/* Add font size to left and right buttons*/
+.paginationItem.buttonsLightMode,
+.paginationItem.buttonsDarkMode {
+  font-size: var(--text-sm);
 }
 
 /* On light mode */
@@ -32,16 +37,12 @@
   background-color: rgba(227, 227, 227, 0.2);
 }
 
-.pageNumber {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  min-width: 2.5rem;
-  min-height: 2.5rem;
+/* Add font size to page number and ellipsis items */
+.paginationItem.pageNumberLightMode,
+.paginationItem.pageNumberDarkMode,
+.paginationItem.ellipsisLight,
+.paginationItem.ellipsisDark {
   font-size: var(--text-lg);
-  border: 1px solid white;
-  border-radius: var(--principal-border-radius);
-  background-color: inherit;
 }
 
 /* On light mode */

--- a/src/components/pagination/renderPageNumbers/renderPageNumbers.module.css
+++ b/src/components/pagination/renderPageNumbers/renderPageNumbers.module.css
@@ -1,0 +1,15 @@
+.pageNumber {
+  min-width: 2.5rem;
+  min-height: 2.5rem;
+  text-align: center;
+  font-size: var(--text-md);
+  border-radius: var(--principal-border-radius);
+  background-color: inherit;
+}
+
+.pageNumber.active {
+}
+
+.active {
+  background-color: orange;
+}

--- a/src/components/pagination/renderPageNumbers/renderPageNumbers.module.css
+++ b/src/components/pagination/renderPageNumbers/renderPageNumbers.module.css
@@ -18,15 +18,15 @@
 /* On light mode */
 .buttonsLightMode {
   background-color: var(--background-tertiary-light-mode);
-  border-color: rgb(43, 43, 43, 0.3);
+  border-color: rgba(43, 43, 43, 0.3);
   color: var(--text-primary-dark);
 }
 
 .buttonsLightMode:hover {
-  background-color: rgba(0, 0, 0, 0.2);
+  background-color: rgba(15, 17, 17, 0.2);
 }
 
-/* On light mode */
+/* On dark mode */
 .buttonsDarkMode {
   background-color: var(--background-tertiary-dark-mode);
   border-color: rgba(227, 230, 230, 0.3);
@@ -48,7 +48,7 @@
 /* On light mode */
 .pageNumberLightMode {
   background-color: var(--background-tertiary-light-mode);
-  border-color: rgb(43, 43, 43, 0.3);
+  border-color: rgba(43, 43, 43, 0.3);
   color: var(--text-primary-dark);
 }
 
@@ -81,7 +81,7 @@
 /* On light mode */
 .ellipsisLight {
   background-color: var(--background-tertiary-light-mode);
-  border-color: rgb(43, 43, 43, 0.3);
+  border-color: rgba(43, 43, 43, 0.3);
   color: var(--text-primary-dark);
 }
 

--- a/src/components/pagination/renderPageNumbers/renderPageNumbers.module.css
+++ b/src/components/pagination/renderPageNumbers/renderPageNumbers.module.css
@@ -1,3 +1,37 @@
+.buttons {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-width: 2.5rem;
+  min-height: 2.5rem;
+  font-size: var(--text-sm);
+  border-width: 1px;
+  border-style: solid;
+  border-radius: var(--principal-border-radius);
+}
+
+/* On light mode */
+.buttonsLightMode {
+  background-color: var(--background-tertiary-light-mode);
+  border-color: rgb(43, 43, 43, 0.3);
+  color: var(--text-primary-dark);
+}
+
+.buttonsLightMode:hover {
+  background-color: rgba(0, 0, 0, 0.2);
+}
+
+/* On light mode */
+.buttonsDarkMode {
+  background-color: var(--background-tertiary-dark-mode);
+  border-color: rgba(227, 230, 230, 0.3);
+  color: var(--text-primary-light);
+}
+
+.buttonsDarkMode:hover {
+  background-color: rgba(227, 227, 227, 0.2);
+}
+
 .pageNumber {
   display: flex;
   justify-content: center;

--- a/src/components/pagination/renderPageNumbers/renderPageNumbers.module.css
+++ b/src/components/pagination/renderPageNumbers/renderPageNumbers.module.css
@@ -24,6 +24,7 @@
 
 .buttonsLightMode:hover {
   background-color: rgba(15, 17, 17, 0.2);
+  border-color: rgba(43, 43, 43, 0.3);
 }
 
 /* On dark mode */

--- a/src/components/pagination/utils/renderPageNumbers/renderPageNumbers.tsx
+++ b/src/components/pagination/utils/renderPageNumbers/renderPageNumbers.tsx
@@ -1,0 +1,64 @@
+const renderPageNumbers = (
+  totalPages: number,
+  currentPage: number,
+  handlePageChange: (page: number) => void,
+  maxPagesToShow: number
+): JSX.Element[] => {
+  // Array to store page numbers
+  const pageNumbers = [];
+
+  // Calculate the first page to display
+  let startPage = Math.max(2, currentPage - Math.floor(maxPagesToShow / 2));
+  // Calculate the last page to display
+  const endPage = Math.min(totalPages - 1, startPage + maxPagesToShow - 1);
+
+  // Adjust startPage if there are not enough pages after endPage
+  if (endPage - startPage < maxPagesToShow - 1) {
+    startPage = Math.max(2, endPage - maxPagesToShow + 1);
+  }
+
+  // Always show page 1
+  pageNumbers.push(
+    <li key="1" className={1 === currentPage ? "active" : ""}>
+      <button onClick={() => handlePageChange(1)} disabled={currentPage === 1}>
+        1
+      </button>
+    </li>
+  );
+
+  // Add ellipsis if startPage is greater than 2
+  if (startPage > 2) {
+    pageNumbers.push(<li key="ellipsis1">...</li>);
+  }
+
+  // Add the page numbers in the range startPage to endPage
+  for (let i = startPage; i <= endPage; i++) {
+    pageNumbers.push(
+      <li key={i} className={i === currentPage ? "active" : ""}>
+        <button onClick={() => handlePageChange(i)}>{i}</button>
+      </li>
+    );
+  }
+
+  // Add ellipsis if endPage is less than totalPages - 1
+  if (endPage < totalPages - 1) {
+    pageNumbers.push(<li key="ellipsis2">...</li>);
+  }
+
+  // Always show the last page
+  pageNumbers.push(
+    <li key={totalPages} className={totalPages === currentPage ? "active" : ""}>
+      <button
+        onClick={() => handlePageChange(totalPages)}
+        disabled={currentPage === totalPages}
+      >
+        {totalPages}
+      </button>
+    </li>
+  );
+
+  // Return page numbers
+  return pageNumbers;
+};
+
+export default renderPageNumbers;

--- a/src/features/home/components/searchBar/SearchBar.tsx
+++ b/src/features/home/components/searchBar/SearchBar.tsx
@@ -34,7 +34,7 @@ const SearchBar: FC<SearchBarType> = ({
     const { query, errors }: ValidatedType = validateSearch(searchBarValue);
 
     if (Object.keys(errors).length === 0) {
-      navigate(`/search?q=${encodeURIComponent(query)}`);
+      navigate(`/search/1?q=${encodeURIComponent(query)}`);
     } else {
       // Handle errors if necessary
       return;

--- a/src/features/searchResults/components/mainResults/MainResults.tsx
+++ b/src/features/searchResults/components/mainResults/MainResults.tsx
@@ -1,4 +1,5 @@
 /* Components */
+import Pagination from "../../../../components/pagination/Pagination";
 import ResultCard from "../resultCard/ResultCard";
 
 /* Styles */
@@ -7,14 +8,36 @@ import styles from "./mainResults.module.css";
 /* Types */
 import { MainResultsType } from "./MainResultsType";
 
-const MainResults: React.FC<MainResultsType> = ({ results }) => {
+const MainResults: React.FC<MainResultsType> = ({
+  results,
+  totalItems,
+  itemsPerPage,
+  currentPage,
+  setCurrentPage,
+  setOffset,
+}) => {
+  const handlePageChange = (newPage) => {
+    // Get current page elements
+    const startIndex = (newPage - 1) * itemsPerPage; // offset
+    //const endIndex = startIndex + itemsPerPage; // limit
+    setCurrentPage(newPage);
+    setOffset(startIndex);
+  };
   return (
     <main className={styles.container}>
       <div className={styles.grid}>
-        {results.map((item) => (
+        {results?.map((item) => (
           <ResultCard key={item.id} item={item} />
         ))}
       </div>
+
+      <Pagination
+        totalItems={totalItems}
+        itemsPerPage={20}
+        currentPage={currentPage}
+        onPageChange={handlePageChange}
+        maxPagesToShow={5}
+      />
     </main>
   );
 };

--- a/src/features/searchResults/components/mainResults/MainResults.tsx
+++ b/src/features/searchResults/components/mainResults/MainResults.tsx
@@ -12,17 +12,7 @@ const MainResults: React.FC<MainResultsType> = ({
   results,
   totalItems,
   itemsPerPage,
-  currentPage,
-  setCurrentPage,
-  setOffset,
 }) => {
-  const handlePageChange = (newPage) => {
-    // Get current page elements
-    const startIndex = (newPage - 1) * itemsPerPage; // offset
-    //const endIndex = startIndex + itemsPerPage; // limit
-    setCurrentPage(newPage);
-    setOffset(startIndex);
-  };
   return (
     <main className={styles.container}>
       <div className={styles.grid}>
@@ -30,12 +20,9 @@ const MainResults: React.FC<MainResultsType> = ({
           <ResultCard key={item.id} item={item} />
         ))}
       </div>
-
       <Pagination
         totalItems={totalItems}
-        itemsPerPage={20}
-        currentPage={currentPage}
-        onPageChange={handlePageChange}
+        itemsPerPage={itemsPerPage}
         maxPagesToShow={5}
       />
     </main>

--- a/src/features/searchResults/components/mainResults/MainResultsType.ts
+++ b/src/features/searchResults/components/mainResults/MainResultsType.ts
@@ -3,4 +3,6 @@ import { Item } from "../../../../types/ResultAPIType";
 
 export type MainResultsType = {
   results: Item[];
+  totalItems: number;
+  itemsPerPage: number;
 };

--- a/src/features/searchResults/components/mainResults/mainResults.module.css
+++ b/src/features/searchResults/components/mainResults/mainResults.module.css
@@ -4,6 +4,8 @@
   justify-content: center;
   width: 100%;
   margin-bottom: var(--spacing-lg);
+
+  flex-wrap: wrap;
 }
 
 .grid {

--- a/src/features/searchResults/components/mainResults/mainResults.module.css
+++ b/src/features/searchResults/components/mainResults/mainResults.module.css
@@ -1,11 +1,10 @@
 .container {
   display: flex;
+  flex-wrap: wrap;
   grid-column: var(--grid-column);
   justify-content: center;
   width: 100%;
   margin-bottom: var(--spacing-lg);
-
-  flex-wrap: wrap;
 }
 
 .grid {

--- a/src/features/searchResults/pages/SearchResults.tsx
+++ b/src/features/searchResults/pages/SearchResults.tsx
@@ -43,7 +43,7 @@ const SearchResults = () => {
   const itemsPerPage = 20;
   const accessToken = "";
 
-  /* /* 
+  /*
 This effect ensures that the page automatically scrolls to the top (y=0) whenever the state of currentPage changes. This ensures that the user starts from the beginning of the page when navigating between them, even when using the browser's scroll arrows and browsing history.
 */
   useEffect(() => {

--- a/src/features/searchResults/pages/SearchResults.tsx
+++ b/src/features/searchResults/pages/SearchResults.tsx
@@ -16,6 +16,7 @@ import styles from "./searchResults.module.css";
 
 /* Types */
 import { Item } from "../../../types/ResultAPIType";
+
 import {
   SecondDataItemType,
   ResultsType,
@@ -35,6 +36,7 @@ const SearchResults = () => {
   const location = useLocation();
   const searchParams = new URLSearchParams(location.search);
   const query = searchParams.get("q");
+
   // Auxiliary state to manage changes in 'query'
   const [queryState, setQueryState] = useState(query);
 
@@ -52,6 +54,7 @@ const SearchResults = () => {
     if (!pages[currentPage - 1]) {
       fetchSearchResults(query, offset);
     }
+    // Añade una nueva entrada al historial de navegación
   }, [query, currentPage]);
 
   useEffect(() => {

--- a/src/features/searchResults/pages/SearchResults.tsx
+++ b/src/features/searchResults/pages/SearchResults.tsx
@@ -18,89 +18,129 @@ import styles from "./searchResults.module.css";
 import { SecondDataItemType } from "./SearchResultsType";
 import { Item } from "../../../types/ResultAPIType";
 
+type storedDataElement = Item[] | undefined;
+
 const SearchResults = () => {
-  const [results, setResults] = useState<Item[]>([]);
-  const [fetchError, setFetchError] = useState(false);
   const [loading, setLoading] = useState(true);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [totalItems, setTotalItems] = useState(0);
+  const [offset, setOffset] = useState(0);
+  const [results, setResults] = useState<Item[]>([]);
+  const [pages, setPages] = useState([]);
+  const [fetchError, setFetchError] = useState(false);
 
   const location = useLocation();
   const searchParams = new URLSearchParams(location.search);
   const query = searchParams.get("q");
 
-  useEffect(() => {
-    const fetchSearchResults = async () => {
-      try {
-        setLoading(true);
-        if (query) {
-          const response: Response = await fetch(
-            `https://api.mercadolibre.com/sites/MLM/search?q=${encodeURIComponent(
-              query
-            )}&status=active&app_version=v2&condition=new&offset=0&limit=20`
+  const itemsPerPage = 20;
+  // const limit = offset + itemsPerPage;
+  // console.log("🚀 ~ SearchResults ~ limit:", limit);
+
+  const fetchSearchResults = async () => {
+    try {
+      setLoading(true);
+      if (query) {
+        const response: Response = await fetch(
+          `https://api.mercadolibre.com/sites/MLM/search?q=${encodeURIComponent(
+            query
+          )}&status=active&app_version=v2&condition=new&offset=${offset}&limit=${itemsPerPage}`
+        );
+
+        if (!response.ok) {
+          setFetchError(true);
+          console.error(
+            `Failed to fetch search results. Status: ${response.status}`
+          );
+        }
+
+        const data = await response.json();
+        setTotalItems(data.paging.total);
+        setResults(data.results);
+
+        // Get IDs from results
+        const itemIds = data.results.map((result: Item) => result.id);
+
+        if (itemIds.length > 0) {
+          // Make the second request with the IDs to get the ID and images of each item
+          const idsString = itemIds.join(",");
+
+          // The ML API receives a series of IDs, followed by the attributes that will be requested
+          const secondResponse: Response = await fetch(
+            `https://api.mercadolibre.com/items?ids=${idsString}&attributes=id,pictures`
           );
 
-          if (!response.ok) {
+          if (!secondResponse.ok) {
             setFetchError(true);
-            console.error(
-              `Failed to fetch search results. Status: ${response.status}`
-            );
-          }
-
-          const data = await response.json();
-          setResults(data.results);
-
-          // Get IDs from results
-          const itemIds = data.results.map((result: Item) => result.id);
-
-          if (itemIds.length > 0) {
-            // Make the second request with the IDs to get the ID and images of each item
-            const idsString = itemIds.join(",");
-
-            // The ML API receives a series of IDs, followed by the attributes that will be requested
-            const secondResponse: Response = await fetch(
-              `https://api.mercadolibre.com/items?ids=${idsString}&attributes=id,pictures`
-            );
-
-            if (!secondResponse.ok) {
-              setFetchError(true);
-              if (secondResponse.status === 429) {
-                console.log("Too many requests: ", secondResponse.status);
-                return results;
-              }
-              throw new Error(
-                `Failed to fetch item details. Status: ${secondResponse.status}`
+            if (secondResponse.status === 429) {
+              console.warn(
+                "WARNING: Too many requests, status: ",
+                secondResponse.status
               );
+              return results;
             }
-
-            const secondData = await secondResponse.json();
-            // Update the results that were in the state by adding the 'pictureArr' property to each item which will contain the images obtained in secondResponse.
-            setResults((prevResults) => {
-              return prevResults.map((result) => {
-                const matchingItem = secondData.find(
-                  (item: SecondDataItemType) =>
-                    item.code === 200 && item.body.id === result.id
-                );
-
-                if (matchingItem && matchingItem.body.pictures) {
-                  return {
-                    ...result,
-                    picturesArr: matchingItem.body.pictures,
-                  };
-                }
-
-                return result;
-              });
-            });
+            throw new Error(
+              `Failed to fetch item pictures. Status: ${secondResponse.status}`
+            );
           }
+
+          const secondData = await secondResponse.json();
+          // Update the results that were in the state by adding the 'pictureArr' property to each item which will contain the images obtained in secondResponse.
+          setResults((prevResults) => {
+            return prevResults.map((result) => {
+              const matchingItem = secondData.find(
+                (item: SecondDataItemType) =>
+                  item.code === 200 && item.body.id === result.id
+              );
+
+              if (matchingItem && matchingItem.body.pictures) {
+                return {
+                  ...result,
+                  picturesArr: matchingItem.body.pictures,
+                };
+              }
+
+              return result;
+            });
+          });
         }
-      } catch (error) {
-        console.error("Error fetching search results:", error);
-      } finally {
-        setLoading(false);
       }
-    };
+    } catch (error) {
+      console.error("Error fetching search results:", error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    setPages([]);
+    setOffset(0);
+    setCurrentPage(1);
 
     fetchSearchResults();
   }, [query]);
+
+  useEffect(() => {
+    console.log("🚀 ~ SearchResults ~ offset:", offset);
+
+    const updatePages = async () => {
+      await fetchSearchResults();
+
+      // const newItemsPerPage = results;
+
+      setPages((prevPages) => {
+        const updatedPages = [...prevPages];
+        updatedPages[currentPage - 1] = results;
+        return updatedPages;
+      });
+    };
+    console.log("Items at current page: ", pages[currentPage - 1]);
+    console.log("All the pages: ", pages);
+
+    if (!pages[currentPage - 1] || !pages[currentPage - 1].length) {
+      updatePages();
+    } else console.log("do nothing...");
+  }, [currentPage, offset, results, pages]);
 
   let content;
 
@@ -121,7 +161,16 @@ const SearchResults = () => {
       />
     );
   } else {
-    content = <MainResults results={results} />;
+    content = (
+      <MainResults
+        results={pages[currentPage - 1]}
+        totalItems={totalItems}
+        itemsPerPage={itemsPerPage}
+        currentPage={currentPage}
+        setCurrentPage={setCurrentPage}
+        setOffset={setOffset}
+      />
+    );
   }
 
   return (
@@ -132,6 +181,14 @@ const SearchResults = () => {
         </div>
       )}
       {content}
+      {/*       <MainResults
+        results={pages[currentPage - 1]}
+        totalItems={totalItems}
+        itemsPerPage={itemsPerPage}
+        currentPage={currentPage}
+        setCurrentPage={setCurrentPage}
+        setOffset={setOffset}
+      /> */}
     </Layout>
   );
 };

--- a/src/features/searchResults/pages/SearchResults.tsx
+++ b/src/features/searchResults/pages/SearchResults.tsx
@@ -129,7 +129,6 @@ const SearchResults = () => {
       updatedPages[currentPage - 1] = results;
       return updatedPages;
     });
-    console.log("🚀 ~ SearchResults ~ pages:", pages);
   }, [results]);
 
   let content;

--- a/src/features/searchResults/pages/SearchResults.tsx
+++ b/src/features/searchResults/pages/SearchResults.tsx
@@ -43,6 +43,13 @@ const SearchResults = () => {
   const itemsPerPage = 20;
   const accessToken = "";
 
+  /* /* 
+This effect ensures that the page automatically scrolls to the top (y=0) whenever the state of currentPage changes. This ensures that the user starts from the beginning of the page when navigating between them, even when using the browser's scroll arrows and browsing history.
+*/
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [currentPage]);
+
   useEffect(() => {
     if (query !== queryState) {
       setPages([]);

--- a/src/features/searchResults/pages/SearchResults.tsx
+++ b/src/features/searchResults/pages/SearchResults.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState, useEffect } from "react";
 import { useLocation } from "react-router-dom";
 import {
   faFaceSadTear,
@@ -32,97 +32,10 @@ const SearchResults = () => {
   const location = useLocation();
   const searchParams = new URLSearchParams(location.search);
   const query = searchParams.get("q");
+  // Auxiliary state to manage changes in 'query'
+  const [queryState, setQueryState] = useState(query);
 
   const itemsPerPage = 20;
-  // const limit = offset + itemsPerPage;
-  // console.log("🚀 ~ SearchResults ~ limit:", limit);
-  /*   const fetchSearchResults = async () => {
-    try {
-      setLoading(true);
-      if (query) {
-        const response: Response = await fetch(
-          `https://api.mercadolibre.com/sites/MLM/search?q=${encodeURIComponent(
-            query
-          )}&status=active&app_version=v2&condition=new&offset=${offset}&limit=${itemsPerPage}`
-        );
-        if (!response.ok) {
-          setFetchError(true);
-          console.error(
-            `Failed to fetch search results. Status: ${response.status}`
-          );
-        } else {
-          const data = await response.json();
-          setTotalItems(data.paging.total);
-          setResults(data.results);
-          const itemIds = data.results.map((result: Item) => result.id);
-          if (itemIds.length > 0) {
-            const idsString = itemIds.join(",");
-            const secondResponse: Response = await fetch(
-              `https://api.mercadolibre.com/items?ids=${idsString}&attributes=id,pictures`
-            );
-            if (!secondResponse.ok) {
-              setFetchError(true);
-              if (secondResponse.status === 429) {
-                console.warn(
-                  "WARNING: Too many requests, status: ",
-                  secondResponse.status
-                );
-                return results;
-              }
-              throw new Error(
-                `Failed to fetch item pictures. Status: ${secondResponse.status}`
-              );
-            } else {
-              const secondData = await secondResponse.json();
-              setResults((prevResults) => {
-                return prevResults.map((result) => {
-                  const matchingItem = secondData.find(
-                    (item: SecondDataItemType) =>
-                      item.code === 200 && item.body.id === result.id
-                  );
-                  if (matchingItem && matchingItem.body.pictures) {
-                    return {
-                      ...result,
-                      picturesArr: matchingItem.body.pictures,
-                    };
-                  }
-                  return result;
-                });
-              });
-            }
-          }
-        }
-      }
-    } catch (error) {
-      console.error("Error fetching search results:", error);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  useEffect(() => {
-    setPages([]);
-    setOffset(0);
-    setCurrentPage(1);
-    fetchSearchResults();
-  }, [query]);
-
-  useEffect(() => {
-    const updatePages = async () => {
-      if (!pages[currentPage - 1] || !pages[currentPage - 1].length) {
-        await fetchSearchResults();
-        setPages((prevPages) => {
-          const updatedPages = [...prevPages];
-          updatedPages[currentPage - 1] = results;
-          return updatedPages;
-        });
-      } else {
-        console.log("do nothing...");
-      }
-    };
-
-    updatePages();
-  }, [currentPage, offset, results, pages]); */
 
   const fetchSearchResults = async (query, offset) => {
     try {
@@ -199,17 +112,16 @@ const SearchResults = () => {
   };
 
   useEffect(() => {
-    setPages([]);
-    setOffset(0);
-    setCurrentPage(1);
-    fetchSearchResults(query, 0);
-  }, [query]);
-
-  useEffect(() => {
+    if (query !== queryState) {
+      setPages([]);
+      setOffset(0);
+      setCurrentPage(1);
+      setQueryState(query);
+    }
     if (!pages[currentPage - 1]) {
       fetchSearchResults(query, offset);
     }
-  }, [currentPage]);
+  }, [query, currentPage]);
 
   useEffect(() => {
     setPages((prevPages) => {

--- a/src/features/searchResults/pages/SearchResults.tsx
+++ b/src/features/searchResults/pages/SearchResults.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { useLocation } from "react-router-dom";
+import { useLocation, useParams } from "react-router-dom";
 import {
   faFaceSadTear,
   faMagnifyingGlassMinus,
@@ -28,11 +28,11 @@ const SearchResults = () => {
   const [loading, setLoading] = useState(true);
   const [currentPage, setCurrentPage] = useState(1);
   const [totalItems, setTotalItems] = useState(0);
-  const [offset, setOffset] = useState(0);
   const [results, setResults] = useState<ResultsType>([]);
   const [pages, setPages] = useState<PagesType>([]);
   const [fetchError, setFetchError] = useState(false);
 
+  const { page } = useParams();
   const location = useLocation();
   const searchParams = new URLSearchParams(location.search);
   const query = searchParams.get("q");
@@ -41,21 +41,25 @@ const SearchResults = () => {
   const [queryState, setQueryState] = useState(query);
 
   const itemsPerPage = 20;
-  const accessToken =
-    "APP_USR-6094347472813542-040223-31d606220c69045a9a9a328f1421aed7-1525368630";
+  const accessToken = "";
 
   useEffect(() => {
     if (query !== queryState) {
       setPages([]);
-      setOffset(0);
-      setCurrentPage(1);
       setQueryState(query);
     }
+  }, [query]);
+
+  useEffect(() => {
+    const currentPage = Number(page);
+    // currentPage is updated every time the page changes to show the updated page at all times
+    setCurrentPage(currentPage);
+
     if (!pages[currentPage - 1]) {
+      const offset = currentPage * itemsPerPage - itemsPerPage;
       fetchSearchResults(query, offset);
     }
-    // Añade una nueva entrada al historial de navegación
-  }, [query, currentPage]);
+  }, [query, location, pages]);
 
   useEffect(() => {
     setPages((prevPages) => {
@@ -95,12 +99,12 @@ const SearchResults = () => {
 
           // The ML API receives a series of IDs, followed by the attributes that will be requested
           const secondResponse = await fetch(
-            `https://api.mercadolibre.com/items?ids=${idsString}&attributes=id,pictures`,
+            `https://api.mercadolibre.com/items?ids=${idsString}&attributes=id,pictures` /* ,
             {
               headers: {
                 Authorization: `Bearer ${accessToken}`,
               },
-            }
+            } */
           );
 
           if (!secondResponse.ok) {
@@ -169,9 +173,6 @@ const SearchResults = () => {
         results={pages[currentPage - 1]}
         totalItems={totalItems}
         itemsPerPage={itemsPerPage}
-        currentPage={currentPage}
-        setCurrentPage={setCurrentPage}
-        setOffset={setOffset}
       />
     );
   }
@@ -184,14 +185,6 @@ const SearchResults = () => {
         </div>
       )}
       {content}
-      {/*       <MainResults
-        results={pages[currentPage - 1]}
-        totalItems={totalItems}
-        itemsPerPage={itemsPerPage}
-        currentPage={currentPage}
-        setCurrentPage={setCurrentPage}
-        setOffset={setOffset}
-      /> */}
     </Layout>
   );
 };

--- a/src/features/searchResults/pages/SearchResultsType.ts
+++ b/src/features/searchResults/pages/SearchResultsType.ts
@@ -1,4 +1,4 @@
-import { Picture } from "../../../types/ResultAPIType";
+import { Item, Picture } from "../../../types/ResultAPIType";
 
 export type SecondDataItemType = {
   code: number;
@@ -7,3 +7,9 @@ export type SecondDataItemType = {
     pictures?: Picture[];
   };
 };
+
+export type ResultsType = Item[];
+
+export type PagesType = ResultsType[];
+
+export type QueryType = string | null;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,8 +2,9 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import { createHashRouter, RouterProvider } from "react-router-dom";
 
-import { ThemeProvider } from "./contexts/ThemeProvider";
 import routes from "./routes";
+
+import { ThemeProvider } from "./contexts/ThemeProvider";
 
 import "./index.module.css";
 

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -9,7 +9,7 @@ const routes = [
     exact: true,
   },
   {
-    path: "/search",
+    path: "/search/:page",
     element: <SearchResults />,
     exact: true,
   },


### PR DESCRIPTION
# Pull Request for Issue #30: Pagination of results

## Description
This Pull Request adds pagination to the search results list, allowing navigation between 20 items per page.

## Changes Made
- Each page contains a maximum of 20 elements.
- The pagination includes "Previous" and "Next" buttons. These buttons are disabled if there are no elements to move to after clicking.
- In the middle of the 'previous' and 'next' navigation buttons, numbered buttons are placed from 1 to the last page. However, only a maximum of six of these buttons are accessible for users to navigate through the results, being the case of the buttons for pages 1 and last, two buttons previous to the current page and two more buttons that follow the button of the current page.
- All buttons show a cursor pointer when hovering over them, except for the button that represents the current page. The latter shows a color change highlighting for the user that they are on that page.
- The pagination is centered and appears at the end of the search results display if the search was successful.

## Images

![Captura de pantalla 2024-04-15 215543](https://github.com/AaronTDR/layout-building/assets/72379189/e42f2255-4165-4028-b391-acdd5be6be9c)
![Captura de pantalla 2024-04-15 215557](https://github.com/AaronTDR/layout-building/assets/72379189/a0175698-daea-4335-8227-b141b1fed421)
![Captura de pantalla 2024-04-15 215627](https://github.com/AaronTDR/layout-building/assets/72379189/d047fd5f-be9d-46ca-9bb4-1ed65f0eb96e)

![Captura de pantalla 2024-04-15 215802](https://github.com/AaronTDR/layout-building/assets/72379189/8a8945af-bdd1-4358-a34c-eb678200ca82)

![Captura de pantalla 2024-04-15 215748](https://github.com/AaronTDR/layout-building/assets/72379189/e9f96b9b-83ab-4de0-84f3-7a3bd8b03c71)
![Captura de pantalla 2024-04-15 215736](https://github.com/AaronTDR/layout-building/assets/72379189/cbaa387e-03ef-4562-bfe6-5a770d088034)

