### PR TITLE
fix: Add Id property to items displayed in lists - #37

### DIFF
--- a/src/components/list/List.tsx
+++ b/src/components/list/List.tsx
@@ -12,7 +12,7 @@ const List = ({ ulTagCss, liTagCss, elements }: ListType) => {
   return (
     <ul className={cssUl}>
       {elements.map((el, i) => (
-        <li key={i} onClick={el.onClick} className={cssLi}>
+        <li key={el.id || i} onClick={el.onClick} className={cssLi}>
           <Link
             to={el.path}
             title={(el.titleLink && el.titleLink) || ""}

--- a/src/components/list/listType.ts
+++ b/src/components/list/listType.ts
@@ -7,6 +7,7 @@ type IconType = {
 };
 
 type Element = {
+  id: string;
   path: string;
   text: string;
   cssLink: string;

--- a/src/components/navList/NavList.tsx
+++ b/src/components/navList/NavList.tsx
@@ -12,7 +12,7 @@ const NavList = ({ ulTagCss, liTagCss, elements }: NavListType) => {
   return (
     <ul className={cssUl}>
       {elements.map((el, i) => (
-        <li key={i} onClick={el.onClick} className={cssLi}>
+        <li key={el.id || i} onClick={el.onClick} className={cssLi}>
           <NavLink
             to={el.path}
             title={(el.titleLink && el.titleLink) || ""}

--- a/src/components/navList/NavListType.ts
+++ b/src/components/navList/NavListType.ts
@@ -7,6 +7,7 @@ type IconType = {
 };
 
 type Element = {
+  id: string;
   path: string;
   text: string;
   cssLink: string;

--- a/src/components/stickyBar/StickyBar.tsx
+++ b/src/components/stickyBar/StickyBar.tsx
@@ -48,51 +48,59 @@ import StickyBarContainerTheme from "./theme/StickyBarContainerTheme.module.css"
 import { getThemeClasses } from "../../utils/getThemeClasses/getThemeClasses";
 
 type domainLinksType = {
+  id: string;
   path: string;
   text: string;
   cssLink: string;
-  onClick: () => void;
+  onClick?: () => void;
   cssLinkActive?: string;
 };
 
 const domainLinks = [
   {
+    id: "technology",
     path: "/domain/technology",
     text: "Technology",
     cssLink: borderLinkStyles.borderLink,
     cssLinkActive: borderLinkStyles.active,
   },
   {
+    id: "supermarket",
     path: "/domain/supermarket",
     text: "Supermarket",
     cssLink: borderLinkStyles.borderLink,
     cssLinkActive: borderLinkStyles.active,
   },
   {
+    id: "home-and-furniture",
     path: "/domain/home-and-furniture",
     text: "Home and furniture",
     cssLink: borderLinkStyles.borderLink,
     cssLinkActive: borderLinkStyles.active,
   },
   {
+    id: "construction",
     path: "/domain/construction",
     text: "Construction",
     cssLink: borderLinkStyles.borderLink,
     cssLinkActive: borderLinkStyles.active,
   },
   {
+    id: "clothing",
     path: "/domain/clothing",
     text: "Clothing",
     cssLink: borderLinkStyles.borderLink,
     cssLinkActive: borderLinkStyles.active,
   },
   {
+    id: "sports",
     path: "/domain/sports",
     text: "Sports",
     cssLink: borderLinkStyles.borderLink,
     cssLinkActive: borderLinkStyles.active,
   },
   {
+    id: "vehicles",
     path: "/domain/vehicles",
     text: "Vehicles",
     cssLink: borderLinkStyles.borderLink,
@@ -145,6 +153,7 @@ const StickyBar = () => {
 
   const dropdownMenuPrincipalList = [
     {
+      id: "home",
       path: "/",
       text: "Home",
       cssLink: `${selectedMenuLinkTheme.theme} ${stickyBar.menuLink}`,
@@ -152,6 +161,7 @@ const StickyBar = () => {
       onClick: () => setIsOpen(!isOpen),
     },
     {
+      id: "wish-list",
       path: "#",
       text: "Wish List",
       cssLink: `${selectedMenuLinkTheme.theme} ${stickyBar.menuLink}`,
@@ -159,6 +169,7 @@ const StickyBar = () => {
       onClick: () => setIsOpen(!isOpen),
     },
     {
+      id: "offers",
       path: "#",
       text: "Offers",
       cssLink: `${selectedMenuLinkTheme.theme} ${stickyBar.menuLink}`,
@@ -166,6 +177,7 @@ const StickyBar = () => {
       onClick: () => setIsOpen(!isOpen),
     },
     {
+      id: "trends",
       path: "#",
       text: "Trends",
       cssLink: `${selectedMenuLinkTheme.theme} ${stickyBar.menuLink}`,
@@ -175,6 +187,7 @@ const StickyBar = () => {
   ];
   const dropdownMenuSettingsList = [
     {
+      id: "language",
       path: "#",
       text: "Language",
       cssLink: `${selectedMenuLinkTheme.theme} ${stickyBar.menuLink}`,
@@ -182,6 +195,7 @@ const StickyBar = () => {
       onClick: () => setIsOpen(!isOpen),
     },
     {
+      id: "help",
       path: "#",
       text: "Help",
       cssLink: `${selectedMenuLinkTheme.theme} ${stickyBar.menuLink}`,
@@ -190,6 +204,7 @@ const StickyBar = () => {
     },
   ];
 
+  // Add styles and 'isOpen' state to each domain to use in accordion menu
   const stateAndStylesDropdownMenu = (domains: domainLinksType[]) =>
     domains.map((domain) => {
       const domainCopy = { ...domain };
@@ -263,7 +278,7 @@ const StickyBar = () => {
                 cssContentContainer={`${accordionContainerTheme.theme} ${stickyBar.accordionItemContentContainer}`}
                 expandDirection={"up"}
               >
-                {/* API content will be added...*/}
+                {/* API content will be added...(while the content 'children' is not added typescript show warning)*/}
               </AccordionItem>
             </Accordion>
             <ThemeButton


### PR DESCRIPTION
## Add Id property to items displayed in lists

## Description
This pull request introduces changes in the components List.tsx and NavList.tsx. Now, within the ‘element’ property, the ‘id’ property is required. This eliminates the need to use the index of the iteration over the elements to generate an id that complies with React specifications. In addition, this property has been added to the arrays of elements that are passed as props to the aforementioned components.

**With these modifications, issue #37 that required this adjustment is resolved**