### PR TITLE
Fix/pagination layout 43

### DIFF
--- a/src/components/pagination/pagination.module.css
+++ b/src/components/pagination/pagination.module.css
@@ -1,6 +1,7 @@
 .pagination {
   display: flex;
   justify-content: center;
+  width: 100%;
   margin: var(--spacing-lg) 0;
 }
 .ul {

--- a/src/components/pagination/pagination.module.css
+++ b/src/components/pagination/pagination.module.css
@@ -8,3 +8,10 @@
   display: flex;
   gap: 8px;
 }
+
+@media screen and (max-width: 320px) {
+  .ul {
+    flex-wrap: wrap;
+    font-size: 85%;
+  }
+}

--- a/src/components/pagination/renderPageNumbers/renderPageNumbers.module.css
+++ b/src/components/pagination/renderPageNumbers/renderPageNumbers.module.css
@@ -92,3 +92,20 @@
   border-color: rgba(227, 230, 230, 0.3);
   color: var(--text-primary-light);
 }
+
+@media screen and (max-width: 320px) {
+  .paginationItem {
+    min-width: 2.5em;
+    min-height: 2.5em;
+  }
+  .paginationItem.pageNumberLightMode,
+  .paginationItem.pageNumberDarkMode,
+  .paginationItem.ellipsisLight,
+  .paginationItem.ellipsisDark {
+    font-size: 1em;
+  }
+  .paginationItem.buttonsLightMode,
+  .paginationItem.buttonsDarkMode {
+    font-size: 1em;
+  }
+}

--- a/src/features/searchResults/components/mainResults/MainResults.tsx
+++ b/src/features/searchResults/components/mainResults/MainResults.tsx
@@ -1,3 +1,5 @@
+import React, { useState, useEffect } from "react";
+
 /* Components */
 import Pagination from "../../../../components/pagination/Pagination";
 import ResultCard from "../resultCard/ResultCard";
@@ -14,6 +16,29 @@ const MainResults: React.FC<MainResultsType> = ({
   totalItems,
   itemsPerPage,
 }) => {
+  const [windowWidth, setWindowWidth] = useState(window.innerWidth);
+
+  // Determines the number of pages to display in the pagination
+  useEffect(() => {
+    const handleResize = () => {
+      setWindowWidth(window.innerWidth);
+    };
+
+    window.addEventListener("resize", handleResize);
+
+    return () => {
+      window.removeEventListener("resize", handleResize);
+    };
+  }, []);
+
+  let pagesToShow;
+  if (windowWidth < 435) {
+    pagesToShow = 1;
+  } else if (windowWidth < 512) {
+    pagesToShow = 3;
+  } else {
+    pagesToShow = 5;
+  }
   return (
     <main className={styles.container}>
       <div className={styles.grid}>
@@ -25,7 +50,7 @@ const MainResults: React.FC<MainResultsType> = ({
         <Pagination
           totalItems={totalItems}
           itemsPerPage={itemsPerPage}
-          maxPagesToShow={5}
+          maxPagesToShow={pagesToShow}
         />
       )}
     </main>


### PR DESCRIPTION
## Description

This Pull request solves the overflow that occurred when the screen size was increased beyond 1328px, while avoiding the overflow on screens smaller than 480px that was seen when displaying the Pagination component.


## Screenshots

***>1328px:***
![image](https://github.com/AaronTDR/layout-building/assets/72379189/d333a9fe-5908-43fa-9144-2ae66c71e802)

***<480px:***
![image](https://github.com/AaronTDR/layout-building/assets/72379189/a4e04429-f2c9-43fc-8c51-976f2e90164b)
